### PR TITLE
Switch to web installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
       "icon": "icon.icns"
     },
     "win": {
-      "target": "NSIS",
+      "target": "nsis-web",
       "icon": "favicon.ico",
       "publish": "github"
     }


### PR DESCRIPTION
Avoid having to download x86 and x64 bundle, web installer detects the machine arch and download the corresponding bundle